### PR TITLE
Fix SMS config keys mismatch

### DIFF
--- a/utils/sms.php
+++ b/utils/sms.php
@@ -21,8 +21,10 @@ class Sms {
         $this->log("开始发送短信");
 
         // 从配置中获取必要信息
-        $accessKeyId     = $this->smsConfig['access_key_id'];
-        $accessKeySecret = $this->smsConfig['access_key_secret'];
+        // 配置文件中的字段为 secret_id 和 secret_key
+        // 为避免名称不一致导致读取失败，这里使用这两个字段
+        $accessKeyId     = $this->smsConfig['secret_id'];
+        $accessKeySecret = $this->smsConfig['secret_key'];
         $signName        = $this->smsConfig['sign_name'];
         $templateCode    = $this->smsConfig['template_ids'][$templateKey];
 


### PR DESCRIPTION
## Summary
- align `Sms` utility with config file key names

## Testing
- `php -l utils/sms.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465f56f020833288a5c1f466fdb8e3